### PR TITLE
tensorbordX.summary.image() expects a numpy array as argument

### DIFF
--- a/lib/nets/network.py
+++ b/lib/nets/network.py
@@ -59,7 +59,7 @@ class Network(nn.Module):
     image = draw_bounding_boxes(\
                       self._gt_image, self._image_gt_summaries['gt_boxes'], self._image_gt_summaries['im_info'])
 
-    return tb.summary.image('GROUND_TRUTH', torch.from_numpy(image[0].astype('float32')/ 255.0).permute(2,0,1))
+    return tb.summary.image('GROUND_TRUTH', image[0].astype('float32')/255.0)
 
   def _add_act_summary(self, key, tensor):
     return tb.summary.histogram('ACT/' + key + '/activations', tensor.data.cpu().numpy(), bins='auto'),


### PR DESCRIPTION
As seen in https://github.com/lanpa/tensorboard-pytorch/blob/master/tensorboardX/summary.py the summary.image() function requires as input argument a

tensor: A 3-D `uint8` or `float32` `Tensor` of shape `[height, width,
        channels]` where `channels` is 1, 3, or 4.

But as seen in line 154 this should not be a pytorch tensor, they mean a numpy. Also the dimensions must not permuted as they already are in the right order.

If you would use the tensorboardX.SummaryWriter class and use add_image() the order should be (3,H,W) and a torch tensor.